### PR TITLE
Property tests and Char8 un/pack fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist
+dist-*
 TAGS
 *.swp

--- a/Data/String/Conv.hs
+++ b/Data/String/Conv.hs
@@ -11,8 +11,8 @@ module Data.String.Conv
   ) where
 
 ------------------------------------------------------------------------------
-import           Data.ByteString.Char8      as B
-import           Data.ByteString.Lazy.Char8 as LB
+import           Data.ByteString            as B
+import           Data.ByteString.Lazy       as LB
 import           Data.Text                  as T
 import           Data.Text.Encoding         as T
 import           Data.Text.Encoding.Error   as T
@@ -61,18 +61,18 @@ toSL = strConv Lenient
 
 
 instance StringConv String String where strConv _ = id
-instance StringConv String B.ByteString where strConv _ = B.pack
-instance StringConv String LB.ByteString where strConv _ = LB.pack
+instance StringConv String B.ByteString where strConv _ = T.encodeUtf8 . T.pack
+instance StringConv String LB.ByteString where strConv _ = LT.encodeUtf8 . LT.pack
 instance StringConv String T.Text where strConv _ = T.pack
 instance StringConv String LT.Text where strConv _ = LT.pack
 
-instance StringConv B.ByteString String where strConv _ = B.unpack
+instance StringConv B.ByteString String where strConv l = T.unpack . decodeUtf8T l
 instance StringConv B.ByteString B.ByteString where strConv _ = id
 instance StringConv B.ByteString LB.ByteString where strConv _ = LB.fromChunks . return
 instance StringConv B.ByteString T.Text where strConv = decodeUtf8T
 instance StringConv B.ByteString LT.Text where strConv l = strConv l . LB.fromChunks . return
 
-instance StringConv LB.ByteString String where strConv _ = LB.unpack
+instance StringConv LB.ByteString String where strConv l = LT.unpack . decodeUtf8LT l
 instance StringConv LB.ByteString B.ByteString where strConv _ = B.concat . LB.toChunks
 instance StringConv LB.ByteString LB.ByteString where strConv _ = id
 instance StringConv LB.ByteString T.Text where strConv l = decodeUtf8T l . strConv l

--- a/string-conv.cabal
+++ b/string-conv.cabal
@@ -26,3 +26,16 @@ library
   exposed-modules:     Data.String.Conv
   build-depends:       base >= 4.4 && < 5, bytestring, text
   ghc-options: -Wall
+
+test-suite tests
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      test
+  main-is:             Main.hs
+  ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
+  build-depends:       base >= 4.4 && < 5
+                     , bytestring
+                     , quickcheck-instances
+                     , string-conv
+                     , tasty
+                     , tasty-quickcheck
+                     , text

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,0 +1,88 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+import Data.ByteString       as B
+import Data.ByteString.Lazy  as LB
+import Data.String.Conv
+import Data.Text             as T
+import Data.Text.Lazy        as LT
+import Test.QuickCheck.Instances.ByteString ()
+import Test.QuickCheck.Instances.Text ()
+import Test.Tasty
+import Test.Tasty.QuickCheck
+
+
+main :: IO ()
+main = defaultMain $ testGroup " tests"
+  [ strictDecoding
+  , lenientDecoding
+  ]
+
+
+strictDecoding :: TestTree
+strictDecoding = testGroup "strict decoding (toS method)"
+  [ testProperty "converting String to String" $ do
+      \s -> s == (toS (toS (s :: String) :: String))
+  , testProperty "converting String to strict ByteString" $ do
+      \s -> s == (toS (toS (s :: String) :: B.ByteString))
+  , testProperty "converting String to lazy ByteString" $ do
+      \s -> s == (toS (toS (s :: String) :: LB.ByteString))
+  , testProperty "converting String to strict Text" $ do
+      \s -> s == (toS (toS (s :: String) :: T.Text))
+  , testProperty "converting String to lazy Text" $ do
+      \s -> s == (toS (toS (s :: String) :: LT.Text))
+  , testProperty "converting strict ByteString to strict ByteString" $ do
+      \s -> s == (toS (toS (s :: B.ByteString) :: B.ByteString))
+  , testProperty "converting strict ByteString to lazy ByteString" $ do
+      \s -> s == (toS (toS (s :: B.ByteString) :: LB.ByteString))
+  , testProperty "converting lazy ByteString to lazy ByteString" $ do
+      \s -> s == (toS (toS (s :: LB.ByteString) :: LB.ByteString))
+  , testProperty "converting strict Text to lazy ByteString" $ do
+      \s -> s == (toS (toS (s :: T.Text) :: LB.ByteString))
+  , testProperty "converting strict Text to strict ByteString" $ do
+      \s -> s == (toS (toS (s :: LB.ByteString) :: B.ByteString))
+  , testProperty "converting strict Text to strict Text" $ do
+      \s -> s == (toS (toS (s :: T.Text) :: T.Text))
+  , testProperty "converting strict Text to lazy Text" $ do
+      \s -> s == (toS (toS (s :: T.Text) :: LT.Text))
+  , testProperty "converting lazy Text to strict ByteString" $ do
+      \s -> s == (toS (toS (s :: LT.Text) :: B.ByteString))
+  , testProperty "converting lazy Text to lazy ByteString" $ do
+      \s -> s == (toS (toS (s :: LT.Text) :: LB.ByteString))
+  , testProperty "converting lazy Text to lazy Text" $ do
+      \s -> s == (toS (toS (s :: LT.Text) :: LT.Text))
+  ]
+
+
+lenientDecoding :: TestTree
+lenientDecoding = testGroup "lenient decoding (toSL method)"
+  [ testProperty "converting String to String" $ do
+      \s -> s == (toSL (toSL (s :: String) :: String))
+  , testProperty "converting String to strict ByteString" $ do
+      \s -> s == (toSL (toSL (s :: String) :: B.ByteString))
+  , testProperty "converting String to lazy ByteString" $ do
+      \s -> s == (toSL (toSL (s :: String) :: LB.ByteString))
+  , testProperty "converting String to strict Text" $ do
+      \s -> s == (toSL (toSL (s :: String) :: T.Text))
+  , testProperty "converting String to lazy Text" $ do
+      \s -> s == (toSL (toSL (s :: String) :: LT.Text))
+  , testProperty "converting strict ByteString to strict ByteString" $ do
+      \s -> s == (toSL (toSL (s :: B.ByteString) :: B.ByteString))
+  , testProperty "converting strict ByteString to lazy ByteString" $ do
+      \s -> s == (toSL (toSL (s :: B.ByteString) :: LB.ByteString))
+  , testProperty "converting lazy ByteString to lazy ByteString" $ do
+      \s -> s == (toSL (toSL (s :: LB.ByteString) :: LB.ByteString))
+  , testProperty "converting strict Text to lazy ByteString" $ do
+      \s -> s == (toSL (toSL (s :: T.Text) :: LB.ByteString))
+  , testProperty "converting strict Text to strict ByteString" $ do
+      \s -> s == (toSL (toSL (s :: LB.ByteString) :: B.ByteString))
+  , testProperty "converting strict Text to strict Text" $ do
+      \s -> s == (toSL (toSL (s :: T.Text) :: T.Text))
+  , testProperty "converting strict Text to lazy Text" $ do
+      \s -> s == (toSL (toSL (s :: T.Text) :: LT.Text))
+  , testProperty "converting lazy Text to strict ByteString" $ do
+      \s -> s == (toSL (toSL (s :: LT.Text) :: B.ByteString))
+  , testProperty "converting lazy Text to lazy ByteString" $ do
+      \s -> s == (toSL (toSL (s :: LT.Text) :: LB.ByteString))
+  , testProperty "converting lazy Text to lazy Text" $ do
+      \s -> s == (toSL (toSL (s :: LT.Text) :: LT.Text))
+  ]


### PR DESCRIPTION
This adds a suite of property tests that expose the Char8 breakage that can occur when using Data.ByteString.Char8 pack and unpack. The PR also includes a fix for this using Text encode and decode.